### PR TITLE
Revert removal of `psr/container:^1.x`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,16 +21,16 @@
         "php": "~8.2 || ~8.3 || ~8.4",
         "gsteel/dot": "^1.7",
         "gsteel/looker": "^0",
-        "laminas/laminas-servicemanager": "^3.22.0 || ^4.0",
+        "laminas/laminas-servicemanager": "^3.23.0 || ^4.0",
         "mezzio/mezzio-helpers": "^5.15",
         "mezzio/mezzio-template": "^2.11",
-        "psr/container": "^2.0",
+        "psr/container": "^1.1.2 || ^2.0",
         "webmozart/assert": "^1.11"
     },
     "require-dev": {
         "doctrine/coding-standard": "^12.0",
         "laminas/laminas-config-aggregator": "^1.17.0",
-        "phpunit/phpunit": "^11.5.4",
+        "phpunit/phpunit": "^11.5.5",
         "psalm/plugin-phpunit": "^0.19.2",
         "squizlabs/php_codesniffer": "^3.11.3",
         "vimeo/psalm": "^6.0.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "676a4e48f778f3c18eeebb4efe8613b2",
+    "content-hash": "54a9735ba1aabf353a03f774989bdaa1",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -3014,16 +3014,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "11.5.4",
+            "version": "11.5.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "e0da3559ec50a91f6a6a201473b607b5ccfd9a1b"
+                "reference": "b9a975972f580c0491f834eb0818ad2b32fd8bba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/e0da3559ec50a91f6a6a201473b607b5ccfd9a1b",
-                "reference": "e0da3559ec50a91f6a6a201473b607b5ccfd9a1b",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b9a975972f580c0491f834eb0818ad2b32fd8bba",
+                "reference": "b9a975972f580c0491f834eb0818ad2b32fd8bba",
                 "shasum": ""
             },
             "require": {
@@ -3095,7 +3095,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.4"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.5"
             },
             "funding": [
                 {
@@ -3111,7 +3111,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-01-28T15:03:46+00:00"
+            "time": "2025-01-29T14:01:11+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",


### PR DESCRIPTION
Only allowing container v2 means that only service manager v4 can be installed which is still not widely supported